### PR TITLE
Update Readme, Changelog, and module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,23 @@
 
 ### Features
 - Fixed typo found in variables.tf
+
+## 0.0.4 (2025-06-27)
+
+### Breaking Changes
+- **REMOVED**: `var.native_network_range` variable - native network range is now automatically derived from `subnet_range_mgmt_primary`
+- **CHANGED**: `ingress_cidr_blocks` parameter renamed to `lan_ingress_cidr_blocks` in module call
+- **CHANGED**: Route creation now uses `routed_networks` map instead of single `native_network_range`
+
+### Features
+- **NEW**: Added `var.region` parameter for AWS region specification
+- **NEW**: Added `var.routed_networks` map for defining multiple routed networks behind the vSocket
+- **IMPROVED**: Site location is now automatically derived from AWS region (can still be overridden)
+- **IMPROVED**: Route creation now supports multiple destination networks via `routed_networks` map
+
+### Updates
+- **DEPENDENCIES**: Updated Terraform version requirement from `>= 0.13` to `>= 1.5`
+- **DEPENDENCIES**: Updated AWS provider version requirement to `>= 5.98.0`
+- **DEPENDENCIES**: Updated Cato provider version from `~> 0.0.23` to `~> 0.0.27`
+- **MODULE**: Updated underlying vsocket module source reference
+- **DOCUMENTATION**: Updated README.md with new variable usage examples

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,12 @@
 
 module "cato_deployment" {
-  source                      = "catonetworks/vsocket-aws-ha-vpc/cato"
-  version                     = "~> 0.1.0"
+  # source                      = "catonetworks/vsocket-aws-ha-vpc/cato"
+  # version                     = "=> 0.1.3"
+  # Testing Things  
+  source                      = "../terraform-cato-vsocket-aws-ha-vpc"
   token                       = var.token
   account_id                  = var.account_id
   vpc_id                      = var.vpc_id
-  ingress_cidr_blocks         = var.ingress_cidr_blocks
   lan_ingress_cidr_blocks     = var.ingress_cidr_blocks
   key_pair                    = var.key_pair
   subnet_range_mgmt_primary   = var.subnet_range_mgmt_primary
@@ -21,11 +22,12 @@ module "cato_deployment" {
   lan_eni_primary_ip          = var.lan_eni_primary_ip
   lan_eni_secondary_ip        = var.lan_eni_secondary_ip
   vpc_range                   = var.vpc_network_range
-  native_network_range        = var.native_network_range
   site_name                   = var.site_name
   site_description            = var.site_description
   site_location               = var.site_location
   tags                        = var.tags
+  routed_networks             = var.routed_networks
+  region                      = var.region
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "cato_vpc" {
@@ -39,7 +41,8 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "cato_vpc" {
 
 resource "aws_route" "cato_private_to_tgw" {
   route_table_id         = module.cato_deployment.lan_subnet_route_table_id
-  destination_cidr_block = var.native_network_range
+  for_each               = var.routed_networks
+  destination_cidr_block = each.value
   transit_gateway_id     = var.tgw_id
   depends_on             = [aws_ec2_transit_gateway_vpc_attachment.cato_vpc]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,7 @@
 
 module "cato_deployment" {
-  # source                      = "catonetworks/vsocket-aws-ha-vpc/cato"
-  # version                     = "=> 0.1.3"
-  # Testing Things  
-  source                      = "../terraform-cato-vsocket-aws-ha-vpc"
+  source                      = "catonetworks/vsocket-aws-ha-vpc/cato"
+  version                     = "=> 0.1.3"
   token                       = var.token
   account_id                  = var.account_id
   vpc_id                      = var.vpc_id

--- a/versions.tf
+++ b/versions.tf
@@ -1,12 +1,13 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 5.98.0"
     }
     cato = {
       source  = "registry.terraform.io/catonetworks/cato"
-      version = "~> 0.0.23"
+      version = "~> 0.0.27"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.5"
 }


### PR DESCRIPTION
Main Updates: 
Routing
siteLocation 
Cleanliness

## 0.0.4 (2025-06-27)

### Breaking Changes
- **REMOVED**: `var.native_network_range` variable - native network range is now automatically derived from `subnet_range_mgmt_primary`
- **CHANGED**: `ingress_cidr_blocks` parameter renamed to `lan_ingress_cidr_blocks` in module call
- **CHANGED**: Route creation now uses `routed_networks` map instead of single `native_network_range`

### Features
- **NEW**: Added `var.region` parameter for AWS region specification
- **NEW**: Added `var.routed_networks` map for defining multiple routed networks behind the vSocket
- **IMPROVED**: Site location is now automatically derived from AWS region (can still be overridden)
- **IMPROVED**: Route creation now supports multiple destination networks via `routed_networks` map

### Updates
- **DEPENDENCIES**: Updated Terraform version requirement from `>= 0.13` to `>= 1.5`
- **DEPENDENCIES**: Updated AWS provider version requirement to `>= 5.98.0`
- **DEPENDENCIES**: Updated Cato provider version from `~> 0.0.23` to `~> 0.0.27`
- **MODULE**: Updated underlying vsocket module source reference
- **DOCUMENTATION**: Updated README.md with new variable usage examples
